### PR TITLE
Export per owner with summary

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,11 +17,19 @@ owner_map = {}
 
 # ── Step 1: Orders Processing ─────────────────────────────────
 st.header("Step 1: Orders Processing")
-col1, col2 = st.columns(2)
+col1, col2, col3 = st.columns(3)
 
 with col1:
-    monthly_file = st.file_uploader("Upload Order Line Level Data", type=['xlsx'])
+    month_year = st.text_input(
+        "Month and Year (e.g., Mar-24)",
+        key="month_year",
+    )
 with col2:
+    monthly_file = st.file_uploader(
+        "Upload Order Line Level Data",
+        type=['xlsx'],
+    )
+with col3:
     sku_file = st.file_uploader("Upload SKU List File", type=['xlsx'])
 
 if monthly_file and sku_file:
@@ -176,24 +184,25 @@ if valid_skus is not None and st.session_state.storage_processed:
                 filtered_goods_in['Stock Code'].map(owner_map).fillna('Unknown')
             )
 
-            # ── Build Excel workbook – always ───────────────────
-            owners = sorted(filtered_stock['Responsible Owner'].fillna('Unknown').unique())
-            output = io.BytesIO()
-            with pd.ExcelWriter(output, engine='openpyxl') as writer:
-                currency_fmt = '_-£* #,##0.00_-;-£* #,##0.00_-;_-£* "-"??_-;_-@_-'
+            # ── Build Excel workbooks per owner ─────────────────
+            owners = sorted(
+                filtered_stock['Responsible Owner'].fillna('Unknown').unique()
+            )
+            currency_fmt = '_-£* #,##0.00_-;-£* #,##0.00_-;_-£* "-"??_-;_-@_-'
+            outputs = []
 
-                for owner in owners:
+            for owner in owners:
+                output = io.BytesIO()
+                with pd.ExcelWriter(output, engine='openpyxl') as writer:
                     owner_orders = orders_df[orders_df['Responsible Owner'] == owner]
-                    sheet_name = f"Orders - {owner}"
-                    owner_orders.to_excel(writer, sheet_name=sheet_name, index=False)
-                    ws_orders = writer.sheets[sheet_name]
+                    owner_orders.to_excel(writer, sheet_name='Orders', index=False)
+                    ws_orders = writer.sheets['Orders']
 
                     total_row = len(owner_orders) + 2
                     for col in ['Pick Charge', 'Packaging Charge', 'Label Charge']:
                         col_letter = get_column_letter(owner_orders.columns.get_loc(col) + 1)
-                        ws_orders[f"{col_letter}{total_row}"] = \
-                            f"=SUM({col_letter}2:{col_letter}{total_row-1})"
-                    ws_orders[f"A{total_row}"] = "Total"
+                        ws_orders[f"{col_letter}{total_row}"] = f"=SUM({col_letter}2:{col_letter}{total_row-1})"
+                    ws_orders[f"A{total_row}"] = 'Total'
 
                     for col in ['Pick Charge', 'Packaging Charge', 'Label Charge']:
                         col_letter = get_column_letter(owner_orders.columns.get_loc(col) + 1)
@@ -201,55 +210,74 @@ if valid_skus is not None and st.session_state.storage_processed:
                             ws_orders[f"{col_letter}{r}"].number_format = currency_fmt
 
                     owner_storage = filtered_stock[filtered_stock['Responsible Owner'] == owner]
-                    sheet_name_st = f"Storage - {owner}"
-                    owner_storage.to_excel(writer, sheet_name=sheet_name_st, index=False)
-                    ws_storage = writer.sheets[sheet_name_st]
+                    owner_storage.to_excel(writer, sheet_name='Storage', index=False)
+                    ws_storage = writer.sheets['Storage']
 
                     st_total_row = len(owner_storage) + 2
                     st_cost_col = get_column_letter(owner_storage.columns.get_loc('Cost') + 1)
-                    ws_storage[f"{st_cost_col}{st_total_row}"] = \
-                        f"=SUM({st_cost_col}2:{st_cost_col}{st_total_row-1})"
-                    ws_storage[f"A{st_total_row}"] = "Total"
+                    ws_storage[f"{st_cost_col}{st_total_row}"] = f"=SUM({st_cost_col}2:{st_cost_col}{st_total_row-1})"
+                    ws_storage[f"A{st_total_row}"] = 'Total'
 
                     for r in range(2, st_total_row + 1):
                         ws_storage[f"{st_cost_col}{r}"].number_format = currency_fmt
 
                     owner_goods_in = filtered_goods_in[filtered_goods_in['Responsible Owner'] == owner]
                     if not owner_goods_in.empty:
-                        sheet_name_gi = f"Goods In - {owner}"
-                        owner_goods_in.to_excel(writer, sheet_name=sheet_name_gi, index=False)
-                        ws_gi = writer.sheets[sheet_name_gi]
+                        owner_goods_in.to_excel(writer, sheet_name='Goods In', index=False)
+                        ws_gi = writer.sheets['Goods In']
 
                         gi_total_row = len(owner_goods_in) + 2
-                        gi_cost_col = get_column_letter(
-                            owner_goods_in.columns.get_loc('Cost') + 1
-                        )
-                        ws_gi[f"{gi_cost_col}{gi_total_row}"] = \
-                            f"=SUM({gi_cost_col}2:{gi_cost_col}{gi_total_row-1})"
-                        ws_gi[f"A{gi_total_row}"] = "Total"
+                        gi_cost_col = get_column_letter(owner_goods_in.columns.get_loc('Cost') + 1)
+                        ws_gi[f"{gi_cost_col}{gi_total_row}"] = f"=SUM({gi_cost_col}2:{gi_cost_col}{gi_total_row-1})"
+                        ws_gi[f"A{gi_total_row}"] = 'Total'
 
                         for r in range(2, gi_total_row + 1):
                             ws_gi[f"{gi_cost_col}{r}"].number_format = currency_fmt
 
-                # Auto-size columns on all sheets
-                for ws in writer.sheets.values():
-                    for col_cells in ws.columns:
-                        max_len = max(
-                            len(str(cell.value)) if cell.value else 0
-                            for cell in col_cells
+                    summary_rows = [
+                        {
+                            'Month': month_year,
+                            'Tab Name': 'Orders',
+                            'Total Cost': owner_orders[['Pick Charge', 'Packaging Charge', 'Label Charge']].sum().sum(),
+                        },
+                        {
+                            'Month': month_year,
+                            'Tab Name': 'Storage',
+                            'Total Cost': owner_storage['Cost'].sum(),
+                        },
+                    ]
+                    if not owner_goods_in.empty:
+                        summary_rows.append(
+                            {
+                                'Month': month_year,
+                                'Tab Name': 'Goods In',
+                                'Total Cost': owner_goods_in['Cost'].sum(),
+                            }
                         )
-                        ws.column_dimensions[
-                            get_column_letter(col_cells[0].column)
-                        ].width = max_len + 2
+                    summary_df = pd.DataFrame(summary_rows)
+                    summary_df.to_excel(writer, sheet_name='Summary', index=False)
+                    ws_summary = writer.sheets['Summary']
+                    for r in range(2, len(summary_df) + 2):
+                        ws_summary[f"C{r}"].number_format = currency_fmt
 
-            # ── Download button ────────────────────────────────
-            output.seek(0)
-            st.download_button(
-                label="Download Complete Report",
-                data=output,
-                file_name="monthly_costs_report.xlsx",
-                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            )
+                    for ws in writer.sheets.values():
+                        for col_cells in ws.columns:
+                            max_len = max(
+                                len(str(cell.value)) if cell.value else 0
+                                for cell in col_cells
+                            )
+                            ws.column_dimensions[get_column_letter(col_cells[0].column)].width = max_len + 2
+
+                output.seek(0)
+                outputs.append((owner, output))
+
+            for owner, data_out in outputs:
+                st.download_button(
+                    label=f"Download Report for {owner}",
+                    data=data_out,
+                    file_name=f"Dummy_Products_{month_year}_{owner}.xlsx",
+                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
 
             # Info if Goods In tab absent
             if filtered_goods_in.empty:


### PR DESCRIPTION
## Summary
- request month/year input in step 1
- generate a workbook for each owner
- include Orders, Storage, Goods In and new Summary tab
- filename includes month/year and owner

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68506ed8c1f0832a8625e67a33eb53f7